### PR TITLE
Change sqlite3 to a development dependency

### DIFF
--- a/combi_search.gemspec
+++ b/combi_search.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.2"
-
+  spec.add_development_dependency "sqlite3", "~> 1.3"
+  
   spec.add_dependency "rails", "~> 4.0"
-  spec.add_dependency "sqlite3"
   spec.add_dependency "search_cop"
 end


### PR DESCRIPTION
Sqlite3 is not needed to use the gem, only to run tests.
